### PR TITLE
fix postgres healthcheck and drive version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,8 +147,8 @@ services:
       - POSTGRES_USER=${POSTGRES_DB_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_DB_PASSWD:-password}
     healthcheck:
-      test: ["CMD", "pg_isready"]
-      interval: 10s
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 15s
       timeout: 5s
     networks:
       - mapeditor-net
@@ -167,7 +167,7 @@ services:
       - mapeditor-net
 
   cdo-server:
-    image: esdlmapeditoressim/cdo-server:22.06
+    image: esdlmapeditoressim/cdo-server:23.03
     ports:
       - "2036:2036"
     depends_on:
@@ -184,7 +184,7 @@ services:
       - mapeditor-net
 
   esdl-drive:
-    image: esdlmapeditoressim/esdl-drive:22.07
+    image: esdlmapeditoressim/esdl-drive:23.03
     ports:
       - 9080:9080
       - 9443:9443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_DB_PASSWD:-password}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-      interval: 15s
+      interval: 15s # Set to 15 seconds to prevent a "Connection refused" error from boundary-service trying to connect to postgres. If you receive this error from boundary-service you can try raising this value.
       timeout: 5s
     networks:
       - mapeditor-net


### PR DESCRIPTION
The Postgres Healthcheck returns an error: "FATAL:  role "root" does not exist". This error gets returned when not specifying a user, since the defaut is root. Root doesn't exist and this error is returned. Added the correct user and database variables. We found there also were issues with the boundary_service connecting to postgres, even when the postgres container reported healthy. Adding 5 seconds to the interval fixed this issue.

The cdo-server returns an "out of memoryAborted (core dumped)" error. After adding memory limits to the cdo-server and followed the tutorial, esdl-drive crashed when interacting with it through the mapeditor. Logs show this is caused by mismatched versions. We updated the cdo-server and esdl-drive version to be the same, this fixed the issue.