### PR TITLE
Change docker compose RabbitMQ image to legacy version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,7 +256,7 @@ services:
       - "./BaseInfrastructure/keycloak/:/tmp/config/"
 
   rabbitmq:
-    image: bitnami/rabbitmq:3.9
+    image: bitnamilegacy/rabbitmq:3.9
     ports:
       - 5672:5672
       - 15672:15672


### PR DESCRIPTION
De 3.9 versie bestaat niet meer voor de bitnami deze heeft alleen nog latest. Bitnamilegacy bevat nog wel de 3.9 versie.